### PR TITLE
Polish README

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,7 @@
-#####################################################
-#  PureBasic OpenSource Projects:                   #
-#  https://github.com/fantaisie-software/purebasic  #
-#####################################################
+####################################################
+#  SQUINT Sparse Quad Union Indexed Nibble Trie:   #
+#  https://github.com/idle-PB/SQUINT               #
+####################################################
 
 root = true
 
@@ -52,5 +52,22 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 
+
+## Plain-Text Files
+###################
+[*.txt]
+indent_style = space
+indent_size = unset
+end_of_line = unset
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+
+[LICENSE]
+indent_size = unset
+indent_style = space
+end_of_line = unset
+trim_trailing_whitespace = true
+insert_final_newline = true
 
 # EOF #

--- a/README.md
+++ b/README.md
@@ -1,28 +1,42 @@
-# SQUINT
+# SQUINT (Sparse Quad Union Indexed Nibble Trie)
 
-SQUINT Sparse Quad Union Indexed Nibble Trie
+Squint is the result of realising that you can reduce a Trie from 256 nodes down to 16 nodes at only a cost of twice the lookup by indexing the key by nibbles.
+You then realise you can use a quad to store the indices of 16 offsets into a sparse array and then also reduce the structure down to two control words per node:
 
-Squint is the result of realising that you can reduce a trie from 256 nodes down to 16 nodes
-at only a cost of twice the lookup by indexing the key by nibbles. You then realise you can
-use a quad to store the indices of 16 offsets into a sparse array and then also reduce the structure
-down to two control words per node. *vector,(squint.q | value.i): key->squint->*vector\e[offset]
-resulting in a very compact trie with O(K*2) performance and a memory size 32 times smaller!
+    *vector,(squint.q | value.i): key->squint->*vector\e[offset]
+
+resulting in a very compact Trie with _O_(_K\*2_) performance and a memory size 32 times smaller!
 Four times smaller than a fixed 16 node Trie and eight times smaller again than a 256 node Trie.
-Overhead on x64 reduces to ~8 bytes per byte of input with Unicode16 strings
-Overhead on x86 reduces to ~6 bytes per byte of input with Unicode16 strings
-In pointer sizes thats ~1 word per word of input on x64 And ~1.5 words on x86
-which are similar to the overheads of a QP Trie that's a 1/3 smaller than a Critbit.
-In terms of speed it should be ~2 times that of a Map lookup on average but that's OK as it is O(k*2)
-though if you're frequently looking up values that don't exist it will improve further as it will bail
-out earlier, plus as it's also very cache friendly it may come in closer to 1:1 on lookups.
-Enumerations are of course magnitudes faster, which is why you'd be using a trie in the 1st place
 
-see https://dotat.at/prog/qp/blog-2015-10-04.html
-    https://cr.yp.To/critbit.html
-    https://en.wikipedia.org/wiki/Trie
+With UCS-2 Unicode strings, overhead reduces to ~8 bytes per byte of input on x64 and to ~6 bytes on x86.
+In pointer sizes that's ~1 word per word of input on x64 and ~1.5 words on x86,
+which are similar to the overheads of a QP Trie that's a 1/3 smaller than a Crit-Bit Trie.
 
-Keys can either be numeric integers, UTF8 Or Unicode strings, default is Unicode for convienence and both can be used together, although UTF8 is better for speed.
+In terms of speed it should be ~2 times that of a Map lookup on average but that's OK as it is _O_(_K\*2_) though if you're frequently looking up values that don't exist it will improve further as it will bail out earlier, plus as it's also very cache friendly it may come in closer to 1:1 on lookups.
+Enumerations are of course magnitudes faster, which is why you'd be using a Trie in the 1st place.
 
-Supports: Set, Get, Enum, Walk, Delete and Prune with a flag in Delete
 
-todo: add in a string buffer so the value can be used for something else and still return the keys and value
+Keys can either be numeric integers, UTF-8 or UCS-2 Unicode strings; default is UCS-2 Unicode for convenience and both can be used together, although UTF-8 is better for speed.
+
+Supports: Set, Get, Enum, Walk, Delete and Prune with a flag in Delete.
+
+# TODO
+
+- Add in a string buffer so the value can be used for something else and still return the keys and value.
+
+# References
+
+- _[QP Tries: Smaller and Faster Than Crit-Bit Tries]_ — by [Tony Finch].
+- _[Crit-Bit Trees]_ — by Daniel J. Bernstein.
+- [Wikipedia » Trie][Trie]
+
+<!-----------------------------------------------------------------------------
+                               REFERENCE LINKS
+------------------------------------------------------------------------------>
+
+[QP Tries: Smaller and Faster Than Crit-Bit Tries]: https://dotat.at/prog/qp/blog-2015-10-04.html "Read full article, by Tony Finch"
+[Crit-Bit Trees]: https://cr.yp.To/critbit.html "Read full article, by D. J. Bernstein"
+
+[Trie]: https://en.wikipedia.org/wiki/Trie "See 'Trie' entry at Wikipedia"
+
+[Tony Finch]: https://github.com/fanf2 "View Tony Finch's GitHub profile"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,11 @@
+![SQUINT Version][badge squint]&nbsp;&nbsp;
+![PureBasic Version][badge purebasic]&nbsp;&nbsp;
+[![MIT License][badge license]](./LICENSE)&nbsp;&nbsp;
+![Travis CI][badge travis]
+
 # SQUINT (Sparse Quad Union Indexed Nibble Trie)
+
+- https://github.com/idle-PB/SQUINT
 
 Squint is the result of realising that you can reduce a Trie from 256 nodes down to 16 nodes at only a cost of twice the lookup by indexing the key by nibbles.
 You then realise you can use a quad to store the indices of 16 offsets into a sparse array and then also reduce the structure down to two control words per node:
@@ -36,7 +43,15 @@ Supports: Set, Get, Enum, Walk, Delete and Prune with a flag in Delete.
 
 [QP Tries: Smaller and Faster Than Crit-Bit Tries]: https://dotat.at/prog/qp/blog-2015-10-04.html "Read full article, by Tony Finch"
 [Crit-Bit Trees]: https://cr.yp.To/critbit.html "Read full article, by D. J. Bernstein"
-
 [Trie]: https://en.wikipedia.org/wiki/Trie "See 'Trie' entry at Wikipedia"
+
+<!-- badges  -->
+
+[badge license]: https://img.shields.io/badge/license-MIT-00b5da "Released under the MIT License"
+[badge purebasic]: https://img.shields.io/badge/PureBasic-5.71-yellow "PureBasic 5.71 (x86/x64) — Linux/OS X/Windows"
+[badge squint]: https://img.shields.io/badge/SQUINT-1.0.2-yellow "SQUINT v1.0.2"
+[badge travis]: https://travis-ci.com/idle-PB/SQUINT.svg?branch=master "Travis CI: EditorConfig code styles consistency validation"
+
+<!-- people -->
 
 [Tony Finch]: https://github.com/fanf2 "View Tony Finch's GitHub profile"


### PR DESCRIPTION
A few fixes and polishes to improve readability of the README doc:

* Split text into one-line-per-sentence, for better diffing of contents   edits.
* Polish a couple of sentences, fix some nouns.
* Change occurrences of "Unicode" and "Unicode16" to "UCS-2 Unicode", to   provide a more precise reference to PureBasic Unicode.
* Improve markdown formatting, add reference style links and move external   links to dedicated section.
* Add link to the repository.
* Add the following [badges]:
    - SQUINT version
    - PureBasic version
    - License
    - Travis CI status

Update EditorConfig Settings:

* Add rules for plain-text files.
* Tweak header comments with info about this repo (replacing info from the original repository from which the file was taken).

[badges]: https://shields.io "Visit Shields.io for more info about badges"